### PR TITLE
Fix 'Creation of dynamic property ADORecordSet_pdo::$adodbFetchMode i…

### DIFF
--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -853,6 +853,7 @@ class ADORecordSet_pdo extends ADORecordSet {
 
 	/** @var PDOStatement */
 	var $_queryID;
+	var $adodbFetchMode;
 
 	function __construct($id,$mode=false)
 	{


### PR DESCRIPTION
On PHP 8.2 with php_pdo extensions in the log you might see warnings:

Deprecated in .../vendor/adodb/adodb-php/drivers/adodb-pdo.inc.php line 788: Creation of dynamic property ADORecordSet_pdo::$adodbFetchMode is deprecated

That PR fixes that.